### PR TITLE
Fix spacing for new Github design

### DIFF
--- a/content-styles.css
+++ b/content-styles.css
@@ -39,8 +39,8 @@
 }
 
 .wide .repository-content .discussion-timeline {
-    margin-right: -160px;
-    padding-right: 160px;
+    margin-right: -220px;
+    padding-right: 220px;
     width: 100% !important;
 }
 


### PR DESCRIPTION
The discussion-sidebar has now a 200px width, so the margin/padding of the discussion-timeline should be 220px (200px + 20px to keep the vanilla 20px github margin)