### PR TITLE
Fix TypeError: Illegal invocation

### DIFF
--- a/content-scripts.js
+++ b/content-scripts.js
@@ -10,7 +10,7 @@ function toggleCssClass(state){
   var WIDE_CSS_CLASS = 'wide';
   var body = document.querySelector('body');
   var toggle = state ? body.classList.add : body.classList.remove;
-  toggle(WIDE_CSS_CLASS);
+  toggle.call(body.classList, WIDE_CSS_CLASS);
 }
 
 chrome.storage.onChanged.addListener(function (data) {


### PR DESCRIPTION
Fix an error that is occurring when toggling the wide screen mode on and off in Chrome 66 (probably many versions earlier too)