### PR TITLE
Update match pattern to support github.*.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Widescreen for GitHub",
   "short_name": "Widescreen for Github",
@@ -27,7 +27,7 @@
   "content_scripts": [
     {
       "run_at": "document_end",
-      "matches": ["https://*.github.com/*"],
+      "matches": ["https://*.github.*.com/*"],
       "js": ["content-scripts.js"],
       "css": ["content-styles.css"]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
 
   "name": "Widescreen for GitHub",
   "short_name": "Widescreen for Github",
@@ -27,7 +27,7 @@
   "content_scripts": [
     {
       "run_at": "document_end",
-      "matches": ["https://*.github.*.com/*"],
+      "matches": ["https://*.github.com/*", "https://github.cerner.com/*"],
       "js": ["content-scripts.js"],
       "css": ["content-styles.css"]
     }


### PR DESCRIPTION
Support for organizational websites like github.*.com. Currently the support is limited to '*.github.com/*'. This is benefitial for github.com users from multiple organizations who have their github.com accounts through their organization where the organization's github.com page is of the format 'github.*.com'.