### PR TITLE
Left-align repository information bar

### DIFF
--- a/content-styles.css
+++ b/content-styles.css
@@ -92,6 +92,10 @@
   width: 50% !important;
 }
 
+.wide #js-repo-pjax-container > div.bg-gray-light.pt-3.hide-full-screen.mb-5 > div.d-flex.mb-3.px-3.px-md-4.px-lg-5, .wide #js-repo-pjax-container > div.bg-gray-light.pt-3.hide-full-screen.mb-5 > nav {
+  padding-left: 0 !important;
+}
+
 /* Gists */
 .wide .gist-with-sidebar .gist-content {
   width: 100%;


### PR DESCRIPTION
The original css uses `!important` so in order to override it, I'm using the most amount of specificity in the selectors as possible.

Before:
![Before image](https://user-images.githubusercontent.com/29491356/100414413-8ceac080-30de-11eb-9619-f26858b5f6ec.png)

After:
![After image](https://user-images.githubusercontent.com/29491356/100414415-8d835700-30de-11eb-8045-50ed12f9b33e.png)