### PR TITLE
Properly left-align repository navigation

### DIFF
--- a/content-styles.css
+++ b/content-styles.css
@@ -13,6 +13,10 @@
   max-width: none !important;
 }
 
+.wide .js-repo-nav, .wide #js-repo-pjax-container > div > div {
+  padding-left: 0 !important;
+}
+
 .wide .repository-content {
   width: 100% !important;
   margin-right: auto !important;


### PR DESCRIPTION
Remove the extra left padding on the repository title and navigation bar to align it with the repository contents.