### PR TITLE
Update to manifest version 3 + fix some event issues

### DIFF
--- a/background-scripts.js
+++ b/background-scripts.js
@@ -4,8 +4,8 @@ function updateIcon(state){
 	var color = state ? [255, 0, 0, 255] : [190, 190, 190, 230];
 	var text = state ? 'On' : 'Off';
 
-	chrome.browserAction.setBadgeBackgroundColor({color: color});
-	chrome.browserAction.setBadgeText({text: text});
+	chrome.action.setBadgeBackgroundColor({color: color});
+	chrome.action.setBadgeText({text: text});
 }
 
 function setState(state){
@@ -18,7 +18,7 @@ function getState(callback){
 	});
 }
 
-chrome.browserAction.onClicked.addListener(function () {
+chrome.action.onClicked.addListener(function () {
 	getState(function(state){
 		var newState = !state;
 		updateIcon(newState);

--- a/background-scripts.js
+++ b/background-scripts.js
@@ -29,3 +29,11 @@ chrome.action.onClicked.addListener(function () {
 getState(function(state) {
 	updateIcon(state);
 });
+
+chrome.webNavigation.onDOMContentLoaded.addListener(details => {
+  chrome.tabs.sendMessage(details.tabId, { action: "checkState" });
+});
+
+chrome.webNavigation.onHistoryStateUpdated.addListener(details => {
+  chrome.tabs.sendMessage(details.tabId, { action: "checkState" });
+});

--- a/content-scripts.js
+++ b/content-scripts.js
@@ -21,3 +21,11 @@ chrome.storage.onChanged.addListener(function (data) {
 getState(function(state) {
   toggleCssClass(state);
 });
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "checkState") {
+    getState(function(state) {
+      toggleCssClass(state);
+    });
+  }
+});

--- a/content-styles.css
+++ b/content-styles.css
@@ -101,6 +101,6 @@
   width: calc(100% - 200px);
 }
 
-.wide .container-xl.clearfix.new-discussion-timeline.px-3.px-md-4.px-lg-5 {
-    max-width: 100%;
+.wide .container-xl {
+  max-width: 100%;
 }

--- a/content-styles.css
+++ b/content-styles.css
@@ -104,3 +104,7 @@
 .wide .container-xl {
   max-width: 100%;
 }
+
+#diff-comparison-viewer-container .width-full div {
+  max-width: none !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Widescreen for GitHub",
   "short_name": "Widescreen for Github",
@@ -11,9 +11,10 @@
     "128": "images/icon-128.png"
   },
 
-  "permissions": ["https://github.com/*", "storage"],
+  "permissions": ["storage", "activeTab"],
+  "host_permissions": ["https://github.com/*"],
 
-  "browser_action": {
+  "action": {
     "default_icon": {
       "19": "images/icon-19.png",
       "38": "images/icon-38.png"
@@ -21,7 +22,7 @@
   },
 
   "background": {
-    "scripts": ["background-scripts.js"]
+    "service_worker": "background-scripts.js"
   },
 
   "content_scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     "128": "images/icon-128.png"
   },
 
-  "permissions": ["storage", "activeTab"],
+  "permissions": ["storage", "activeTab", "webNavigation"],
   "host_permissions": ["https://github.com/*"],
 
   "action": {


### PR DESCRIPTION
Thanks for this great plugin!

I fixed some small issues for myself, and thought I could upstream them if you want them also!

- The page stopped being wide after navigating around, and I had to either refresh the page, or toggle the plugin off/on. I fixed that by reapplying the style on each navigation.
- My browser complained that the manifest version 2 was deprecated, so I migrated it to version 3.
- One of the styles was a bit too specific and didn't match on all pages.

Fixes #21 